### PR TITLE
Proposed fix for identifying jar files with a single pom.xml and no p…

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
@@ -1910,5 +1910,4 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"kafka_2.8.2":                                              "org.apache.kafka",
 	"kafka_2.9.1":                                              "org.apache.kafka",
 	"kafka_2.9.2":                                              "org.apache.kafka",
-	"micronaut-aop":                                            "io.micronaut",
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
@@ -1910,4 +1910,5 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"kafka_2.8.2":                                              "org.apache.kafka",
 	"kafka_2.9.1":                                              "org.apache.kafka",
 	"kafka_2.9.2":                                              "org.apache.kafka",
+	"micronaut-aop":                                            "io.micronaut",
 }

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -435,6 +435,10 @@ func (j *archiveParser) updateMatchIfBetter(currentProps pkg.JavaPomProperties, 
 	newProps pkg.JavaPomProperties, parentPath string, projects map[string]*parsedPomProject) (pkg.JavaPomProperties, *parsedPomProject) {
 	// Keep the first match
 	if currentProps.ArtifactID == "" {
+		proj, hasProject := projects[parentPath]
+		if hasProject {
+			return newProps, proj
+		}
 		return newProps, currentPom
 	}
 

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -393,7 +393,7 @@ func (j *archiveParser) discoverMainPackageFromPomInfo(ctx context.Context) (gro
 	properties, _ := pomPropertiesByParentPath(j.archivePath, j.location, j.fileManifest.GlobMatch(false, pomPropertiesGlob))
 	projects, _ := pomProjectByParentPath(j.archivePath, j.location, j.fileManifest.GlobMatch(false, pomXMLGlob))
 
-	// map of all the artifacts in the pom properties, in order to chek exact match with the filename
+	// map of all the artifacts in the pom properties, in order to check exact match with the filename
 	artifactsMap := strset.New()
 	for _, propertiesObj := range properties {
 		artifactsMap.Add(propertiesObj.ArtifactID)
@@ -421,6 +421,13 @@ func (j *archiveParser) discoverMainPackageFromPomInfo(ctx context.Context) (gro
 					break
 				}
 			}
+		}
+	}
+
+	// TEST FIX for having pom.xml but no
+	if len(properties) == 0 && len(projects) == 1 {
+		for _, projectsObj := range projects {
+			parsedPom = projectsObj
 		}
 	}
 

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -148,9 +148,22 @@ func TestParseJar(t *testing.T) {
 						},
 						PomProperties: &pkg.JavaPomProperties{
 							Path:       "META-INF/maven/io.jenkins.plugins/example-jenkins-plugin/pom.properties",
+							Name:       "",
 							GroupID:    "io.jenkins.plugins",
 							ArtifactID: "example-jenkins-plugin",
 							Version:    "1.0-SNAPSHOT",
+						},
+						PomProject: &pkg.JavaPomProject{
+							Path:       "META-INF/maven/io.jenkins.plugins/example-jenkins-plugin/pom.xml",
+							Name:       "Example Jenkins Plugin",
+							GroupID:    "io.jenkins.plugins",
+							ArtifactID: "example-jenkins-plugin",
+							Version:    "1.0-SNAPSHOT",
+							Parent: &pkg.JavaPomParent{
+								GroupID:    "org.jenkins-ci.plugins",
+								ArtifactID: "plugin",
+								Version:    "4.46",
+							},
 						},
 					},
 				},
@@ -189,6 +202,14 @@ func TestParseJar(t *testing.T) {
 								},
 							},
 						},
+						// PomProject: &pkg.JavaPomProject{
+						// 	Path:       "META-INF/maven/io.jenkins.plugins/example-jenkins-plugin/pom.xml",
+						// 	Parent:     &pkg.JavaPomParent{GroupID: "org.jenkins-ci.plugins", ArtifactID: "plugin", Version: "4.46"},
+						// 	GroupID:    "io.jenkins.plugins",
+						// 	ArtifactID: "example-jenkins-plugin",
+						// 	Version:    "1.0-SNAPSHOT",
+						// 	Name:       "Example Jenkins Plugin",
+						// },
 					},
 				},
 				"joda-time": {
@@ -282,6 +303,12 @@ func TestParseJar(t *testing.T) {
 						},
 						PomProperties: &pkg.JavaPomProperties{
 							Path:       "META-INF/maven/org.anchore/example-java-app-maven/pom.properties",
+							GroupID:    "org.anchore",
+							ArtifactID: "example-java-app-maven",
+							Version:    "0.1.0",
+						},
+						PomProject: &pkg.JavaPomProject{
+							Path:       "META-INF/maven/org.anchore/example-java-app-maven/pom.xml",
 							GroupID:    "org.anchore",
 							ArtifactID: "example-java-app-maven",
 							Version:    "0.1.0",
@@ -1127,6 +1154,13 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 				GroupID:    "org.apache.directory.api",
 				ArtifactID: "api-all",
 				Version:    "2.0.0",
+			}, PomProject: &pkg.JavaPomProject{
+				Path:       "META-INF/maven/org.apache.directory.api/api-all/pom.xml",
+				ArtifactID: "api-all",
+				GroupID:    "org.apache.directory.api",
+				Version:    "2.0.0",
+				Name:       "Apache Directory API All",
+				Parent:     &pkg.JavaPomParent{GroupID: "org.apache.directory.api", ArtifactID: "api-parent", Version: "2.0.0"},
 			},
 		},
 	}
@@ -1260,6 +1294,16 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 								{Key: "Specification-Version", Value: "2.15.2"},
 							},
 						},
+						PomProject: &pkg.JavaPomProject{
+							Path:        "META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.xml",
+							ArtifactID:  "jackson-core",
+							GroupID:     "com.fasterxml.jackson.core",
+							Version:     "2.15.2",
+							Name:        "Jackson-core",
+							Description: "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+							URL:         "https://github.com/FasterXML/jackson-core",
+							Parent:      &pkg.JavaPomParent{GroupID: "com.fasterxml.jackson", ArtifactID: "jackson-base", Version: "2.15.2"},
+						},
 						// not under test
 						//ArchiveDigests: []file.Digest{{Algorithm: "sha1", Value: "d8bc1d9c428c96fe447e2c429fc4304d141024df"}},
 					},
@@ -1314,6 +1358,16 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 								{Key: "Created-By", Value: "Apache Maven Bundle Plugin 5.1.8"},
 								{Key: "Specification-Version", Value: "2.15.2"},
 							},
+						},
+						PomProject: &pkg.JavaPomProject{
+							Path:        "META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.xml",
+							ArtifactID:  "jackson-core",
+							GroupID:     "com.fasterxml.jackson.core",
+							Version:     "2.15.2",
+							Name:        "Jackson-core",
+							Description: "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+							URL:         "https://github.com/FasterXML/jackson-core",
+							Parent:      &pkg.JavaPomParent{GroupID: "com.fasterxml.jackson", ArtifactID: "jackson-base", Version: "2.15.2"},
 						},
 						// not under test
 						//ArchiveDigests: []file.Digest{{Algorithm: "sha1", Value: "abd3e329270fc54a2acaceb45420fd5710ecefd5"}},

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -79,9 +79,12 @@ func TestSearchMavenForLicenses(t *testing.T) {
 					ReadCloser: fixture,
 				}, tc.detectNested, tc.config)
 			defer cleanupFn()
+			require.NoError(t, err)
 
 			// assert licenses are discovered from upstream
 			_, _, _, parsedPom := ap.discoverMainPackageFromPomInfo(context.Background())
+			require.NotNil(t, parsedPom, "expected to find pom information in the fixture")
+			require.NotNil(t, parsedPom.project, "expected parsedPom to have a project")
 			resolvedLicenses, _ := ap.maven.ResolveLicenses(context.Background(), parsedPom.project)
 			assert.Equal(t, tc.expectedLicenses, toPkgLicenses(ctx, nil, resolvedLicenses))
 		})

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1163,6 +1163,46 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 		},
 	}
 
+	micronautAop := pkg.Package{
+		Name:      "micronaut-aop",
+		Version:   "4.9.11",
+		PURL:      "pkg:maven/io.micronaut/micronaut-aop@4.9.11",
+		Locations: file.NewLocationSet(file.NewLocation("test-fixtures/jar-metadata/cache/micronaut-aop-4.9.11.jar")),
+		Type:      pkg.JavaPkg,
+		Language:  pkg.Java,
+		Metadata: pkg.JavaArchive{
+			VirtualPath: "test-fixtures/jar-metadata/cache/micronaut-aop-4.9.11.jar",
+			Manifest: &pkg.JavaManifest{
+				Main: []pkg.KeyValue{
+					{
+						Key:   "Manifest-Version",
+						Value: "1.0",
+					},
+					{
+						Key:   "Automatic-Module-Name",
+						Value: "io.micronaut.micronaut_aop",
+					},
+					{
+						Key:   "Implementation-Version",
+						Value: "4.9.11",
+					},
+					{
+						Key:   "Implementation-Title",
+						Value: "Micronaut Core",
+					},
+				},
+			}, PomProject: &pkg.JavaPomProject{
+				Path:        "META-INF/maven/io.micronaut/micronaut-aop/pom.xml",
+				ArtifactID:  "micronaut-aop",
+				GroupID:     "io.micronaut",
+				Version:     "4.9.11",
+				Name:        "Micronaut Core",
+				Description: "Core components supporting the Micronaut Framework",
+				URL:         "https://micronaut.io",
+			},
+		},
+	}
+
 	tests := []struct {
 		name                  string
 		fixtureName           string
@@ -1339,6 +1379,14 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 						//ArchiveDigests: []file.Digest{{Algorithm: "sha1", Value: "d8bc1d9c428c96fe447e2c429fc4304d141024df"}},
 					},
 				},
+			},
+		},
+		{
+			name:          "micronaut-aop",
+			fixtureName:   "micronaut-aop-4.9.11",
+			fileExtension: "jar",
+			expectedPkgs: []pkg.Package{
+				micronautAop,
 			},
 		},
 	}

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
@@ -13,6 +13,7 @@ API_ALL_SOURCES = api-all-2.0.0-sources
 SPRING_INSTRUMENTATION = spring-instrumentation-4.3.0-1.0
 MULTIPLE_MATCHING = multiple-matching-2.11.5
 ORG_MULTIPLE_THENAME = org.multiple-thename
+MICRONAUT_AOP = micronaut-aop-4.9.11
 
 
 .DEFAULT_GOAL := fixtures
@@ -23,7 +24,7 @@ fixtures: $(CACHE_DIR)
 # requirement 2: 'fingerprint' goal to determine if the fixture input that indicates any existing cache should be busted
 fingerprint: $(FINGERPRINT_FILE)
 
-$(CACHE_DIR): $(CACHE_DIR)/$(JACKSON_CORE).jar $(CACHE_DIR)/$(SBT_JACKSON_CORE).jar $(CACHE_DIR)/$(OPENSAML_CORE).jar  $(CACHE_DIR)/$(API_ALL_SOURCES).jar $(CACHE_DIR)/$(SPRING_INSTRUMENTATION).jar $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar
+$(CACHE_DIR): $(CACHE_DIR)/$(JACKSON_CORE).jar $(CACHE_DIR)/$(SBT_JACKSON_CORE).jar $(CACHE_DIR)/$(OPENSAML_CORE).jar  $(CACHE_DIR)/$(API_ALL_SOURCES).jar $(CACHE_DIR)/$(SPRING_INSTRUMENTATION).jar $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar $(CACHE_DIR)/$(MICRONAUT_AOP).jar
 
 $(CACHE_DIR)/$(JACKSON_CORE).jar:
 	mkdir -p $(CACHE_DIR)
@@ -52,6 +53,10 @@ $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar:
 $(CACHE_DIR)/$(ORG_MULTIPLE_THENAME).jar:
 	mkdir -p $(CACHE_DIR)
 	cd $(ORG_MULTIPLE_THENAME) && zip -r $(CACHE_PATH)/$(ORG_MULTIPLE_THENAME).jar .
+
+$(CACHE_DIR)/$(MICRONAUT_AOP).jar:
+	mkdir -p $(CACHE_DIR)
+	cd $(MICRONAUT_AOP) && zip -r $(CACHE_PATH)/$(MICRONAUT_AOP).jar .
 
 # Jenkins plugins typically do not have the version included in the archive name,
 # so it is important to not include it in the generated test fixture

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/micronaut-aop-4.9.11/META-INF/MANIFEST.MF
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/micronaut-aop-4.9.11/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: io.micronaut.micronaut_aop
+Implementation-Version: 4.9.11
+Implementation-Title: Micronaut Core
+

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/micronaut-aop-4.9.11/META-INF/maven/io.micronaut/micronaut-aop/pom.xml
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/micronaut-aop-4.9.11/META-INF/maven/io.micronaut/micronaut-aop/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut</groupId>
+  <artifactId>micronaut-aop</artifactId>
+  <version>4.9.11</version>
+  <name>Micronaut Core</name>
+  <description>Core components supporting the Micronaut Framework</description>
+  <url>https://micronaut.io</url>
+</project>


### PR DESCRIPTION
Fix for java archive parser to use pom.xml metadata even is pom.properties does not exist in archive.

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes - https://github.com/anchore/syft/issues/4260

## Type of change

<!-- Delete any that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue) - https://github.com/anchore/syft/issues/4260

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
